### PR TITLE
docs: fix webpack config for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ module.exports = require("@jsdevtools/karma-config")({
     browserNoActivityTimeout: 5000,             // Set Karma's inactivity timeout
     browsers: ["Opera", "Safari"]               // Always use these browsers, regardless of OS
     webpack: {
+      resolve: {
+          extensions: [".js", ".jsx", ".ts", ".tsx"] // Configure Webpack to resolve TypeScript file
+      },
       mode: "production",                       // Override the default Webpack mode
       module: {
         rules: [


### PR DESCRIPTION
I've tried to use `@jsdevtools/karma-config` in TypeScript project and this `resolve` config is required.

📝 I wish that @jsdevtools/karma-config support TypeScript by default.